### PR TITLE
docs: add GitHub streak stats card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![AHosking's GitHub stats](https://github-readme-stats.vercel.app/api?username=ahosking&count_private=true&show_icons=true&theme=onedark&hide_rank=true&include_all_commits=true)](https://github.com/ahosking)
-
+[![GitHub Streak](https://github-readme-streak-stats.herokuapp.com?user=ahosking&theme=onedark&hide_border=true)](https://github.com/ahosking)
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=ahosking&layout=compact&theme=onedark)](https://github.com/ahosking)
-
 
 # Don't forget about [mermaid](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/)!
 


### PR DESCRIPTION
## Summary
- add GitHub streak stats card to README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e26e68ac832b82f8f7f7e145e6f7